### PR TITLE
ci: scope the workflow token to what each job actually needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ env:
   GO_VERSION: '1.21'
   NODE_VERSION: '18'
 
+# The repository default is a read/write token. Nothing in this workflow
+# writes to the repository, so every job here reads and nothing more.
+permissions:
+  contents: read
+
 jobs:
   # Lint and format check
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,9 @@ on:
     tags:
       - 'v*.*.*'  # Trigger on version tags like v1.0.0
 
+# Read-only by default; the two jobs that write declare what they need.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # Validate the release
@@ -105,6 +104,9 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    # actions/create-release publishes the GitHub release.
+    permissions:
+      contents: write
     needs: [validate, test-release]
 
     steps:
@@ -183,6 +185,10 @@ jobs:
     name: Post Release
     runs-on: ubuntu-latest
     needs: [validate, release]
+    # actions/github-script opens the follow-up documentation issue.
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes the six open `actions/missing-workflow-permissions` code scanning
alerts (#1–#6), and the same defect in `release.yml` that the scanner
does not flag.

## Why these alerts are not noise

The repository default is `default_workflow_permissions: write` with
`can_approve_pull_request_reviews: true`. `ci.yml` declared no
`permissions:` block at all, so all six of its jobs inherited a
read/write `GITHUB_TOKEN` — the lint job and the job whose only steps
`echo` a status message both held a token that can push to `main` and
approve pull requests.

`release.yml` is not flagged only because it declares `contents: write`,
`issues: write` and `pull-requests: write` at the **top** level, which
every job inherits. That is the same defect, spelled out instead of
defaulted: the two jobs that just run tests get write access they never
use, and nothing in the workflow uses `pull-requests` at all.

What turns this from a missing mitigation into something worth fixing is
that every action in both workflows is pinned to a mutable major tag
(`actions/checkout@v4`, `golangci/golangci-lint-action@v8`,
`codecov/codecov-action@v3`, …) rather than a commit SHA. Tag repointing
is the attack that hit `tj-actions/changed-files`; with a write token in
scope, a repointed tag gets commit access. The integration job also runs
`npm install -g @stoplight/prism-cli` and `go mod download` inside that
same job.

## Changes

`ci.yml` is `contents: read` throughout — nothing in it writes to the
repository. `dependency-review-action` needs no more than that as
configured here: it is given `fail-on-severity` only, and posts a PR
comment only when `comment-summary-in-pr` is set. `upload-artifact` and
`codecov-action` do not use `GITHUB_TOKEN` write scopes.

`release.yml` is read by default, with the two jobs that genuinely write
declaring their own scope:

| job | permissions | why |
| --- | --- | --- |
| `validate` | inherits `contents: read` | builds and tests |
| `test-release` | inherits `contents: read` | tests, coverage upload |
| `release` | `contents: write` | `actions/create-release` publishes the release |
| `post-release` | `contents: read`, `issues: write` | `actions/github-script` opens the follow-up docs issue |

## Not included

Two related items are repository settings rather than code, so they are
not in this PR:

- Flipping the repo default to **read-only** (`Settings → Actions →
  General → Workflow permissions`). With this PR merged both workflows
  are explicit, so the default only affects workflows added later — but
  read-only is the safer default for those too.
- Turning off **"Allow GitHub Actions to create and approve pull
  requests"**, which currently lets a workflow token approve a PR and so
  defeats required-review protection. Nothing here needs it.

Separately worth scheduling: pinning actions to commit SHAs, and
replacing `actions/create-release@v1`, which is archived and
unmaintained.
